### PR TITLE
TYPO3 v13 compatibility

### DIFF
--- a/Configuration/FlexForms/CalPlugin.xml
+++ b/Configuration/FlexForms/CalPlugin.xml
@@ -3,339 +3,329 @@
         <langDisable>1</langDisable>
     </meta>
     <sheets>
-        <ewsfeusers_users>
+        <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>title</sheetTitle>
-                </TCEforms>
+                <sheetTitle>title</sheetTitle>
                 <type>array</type>
                 <el>
                     <settings.language>
-                        <TCEforms>
-                            <exclude>1</exclude>
-                            <label>LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.language</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default></default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">Afrikaans</numIndex>
-                                        <numIndex index="1">af</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">Arabic</numIndex>
-                                        <numIndex index="1">ar</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">Arabic (Algeria)</numIndex>
-                                        <numIndex index="1">ar-dz</numIndex>
-                                    </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">Arabic (Kuwait)</numIndex>
-                                        <numIndex index="1">ar-kw</numIndex>
-                                    </numIndex>
-                                    <numIndex index="4" type="array">
-                                        <numIndex index="0">Arabic (Libya)</numIndex>
-                                        <numIndex index="1">ar-ly</numIndex>
-                                    </numIndex>
-                                    <numIndex index="5" type="array">
-                                        <numIndex index="0">Arabic (Morocco)</numIndex>
-                                        <numIndex index="1">ar-ma</numIndex>
-                                    </numIndex>
-                                    <numIndex index="6" type="array">
-                                        <numIndex index="0">Arabic (Saudi Arabia)</numIndex>
-                                        <numIndex index="1">ar-sa</numIndex>
-                                    </numIndex>
-                                    <numIndex index="7" type="array">
-                                        <numIndex index="0">Arabic (Tunisia)</numIndex>
-                                        <numIndex index="1">ar-tn</numIndex>
-                                    </numIndex>
-                                    <numIndex index="8" type="array">
-                                        <numIndex index="0">Bulgarian</numIndex>
-                                        <numIndex index="1">bg</numIndex>
-                                    </numIndex>
-                                    <numIndex index="9" type="array">
-                                        <numIndex index="0">Bosnian</numIndex>
-                                        <numIndex index="1">bs</numIndex>
-                                    </numIndex>
-                                    <numIndex index="10" type="array">
-                                        <numIndex index="0">Catalan</numIndex>
-                                        <numIndex index="1">ca</numIndex>
-                                    </numIndex>
-                                    <numIndex index="11" type="array">
-                                        <numIndex index="0">Czech</numIndex>
-                                        <numIndex index="1">cs</numIndex>
-                                    </numIndex>
-                                    <numIndex index="12" type="array">
-                                        <numIndex index="0">Danish</numIndex>
-                                        <numIndex index="1">da</numIndex>
-                                    </numIndex>
-                                    <numIndex index="13" type="array">
-                                        <numIndex index="0">German</numIndex>
-                                        <numIndex index="1">de</numIndex>
-                                    </numIndex>
-                                    <numIndex index="14" type="array">
-                                        <numIndex index="0">Greek</numIndex>
-                                        <numIndex index="1">el</numIndex>
-                                    </numIndex>
-                                    <numIndex index="15" type="array">
-                                        <numIndex index="0">English</numIndex>
-                                        <numIndex index="1"></numIndex>
-                                    </numIndex>
-                                    <numIndex index="16" type="array">
-                                        <numIndex index="0">English (Australia)</numIndex>
-                                        <numIndex index="1">en-au</numIndex>
-                                    </numIndex>
-                                    <numIndex index="17" type="array">
-                                        <numIndex index="0">English (United Kingdom)</numIndex>
-                                        <numIndex index="1">en-gb</numIndex>
-                                    </numIndex>
-                                    <numIndex index="18" type="array">
-                                        <numIndex index="0">English (New Zealand)</numIndex>
-                                        <numIndex index="1">en-nz</numIndex>
-                                    </numIndex>
-                                    <numIndex index="19" type="array">
-                                        <numIndex index="0">English (United States)</numIndex>
-                                        <numIndex index="1">en-us</numIndex>
-                                    </numIndex>
-                                    <numIndex index="20" type="array">
-                                        <numIndex index="0">Spanish</numIndex>
-                                        <numIndex index="1">es</numIndex>
-                                    </numIndex>
-                                    <numIndex index="21" type="array">
-                                        <numIndex index="0">Estonian</numIndex>
-                                        <numIndex index="1">et</numIndex>
-                                    </numIndex>
-                                    <numIndex index="22" type="array">
-                                        <numIndex index="0">Basque</numIndex>
-                                        <numIndex index="1">eu</numIndex>
-                                    </numIndex>
-                                    <numIndex index="23" type="array">
-                                        <numIndex index="0">Farsi</numIndex>
-                                        <numIndex index="1">fa</numIndex>
-                                    </numIndex>
-                                    <numIndex index="24" type="array">
-                                        <numIndex index="0">Finnish</numIndex>
-                                        <numIndex index="1">fi</numIndex>
-                                    </numIndex>
-                                    <numIndex index="25" type="array">
-                                        <numIndex index="0">French</numIndex>
-                                        <numIndex index="1">fr</numIndex>
-                                    </numIndex>
-                                    <numIndex index="26" type="array">
-                                        <numIndex index="0">French (Canada)</numIndex>
-                                        <numIndex index="1">fr-ca</numIndex>
-                                    </numIndex>
-                                    <numIndex index="27" type="array">
-                                        <numIndex index="0">French (Switzerland)</numIndex>
-                                        <numIndex index="1">fr-ca</numIndex>
-                                    </numIndex>
-                                    <numIndex index="28" type="array">
-                                        <numIndex index="0">Galician</numIndex>
-                                        <numIndex index="1">gl</numIndex>
-                                    </numIndex>
-                                    <numIndex index="29" type="array">
-                                        <numIndex index="0">Hebrew</numIndex>
-                                        <numIndex index="1">he</numIndex>
-                                    </numIndex>
-                                    <numIndex index="30" type="array">
-                                        <numIndex index="0">Hindi</numIndex>
-                                        <numIndex index="1">hi</numIndex>
-                                    </numIndex>
-                                    <numIndex index="31" type="array">
-                                        <numIndex index="0">Croatian</numIndex>
-                                        <numIndex index="1">hr</numIndex>
-                                    </numIndex>
-                                    <numIndex index="32" type="array">
-                                        <numIndex index="0">Hungarian</numIndex>
-                                        <numIndex index="1">hu</numIndex>
-                                    </numIndex>
-                                    <numIndex index="33" type="array">
-                                        <numIndex index="0">Indonesian</numIndex>
-                                        <numIndex index="1">id</numIndex>
-                                    </numIndex>
-                                    <numIndex index="34" type="array">
-                                        <numIndex index="0">Icelandic</numIndex>
-                                        <numIndex index="1">is</numIndex>
-                                    </numIndex>
-                                    <numIndex index="35" type="array">
-                                        <numIndex index="0">Italian</numIndex>
-                                        <numIndex index="1">it</numIndex>
-                                    </numIndex>
-                                    <numIndex index="36" type="array">
-                                        <numIndex index="0">Japanese</numIndex>
-                                        <numIndex index="1">ja</numIndex>
-                                    </numIndex>
-                                    <numIndex index="37" type="array">
-                                        <numIndex index="0">Georgian</numIndex>
-                                        <numIndex index="1">ka</numIndex>
-                                    </numIndex>
-                                    <numIndex index="38" type="array">
-                                        <numIndex index="0">Kazakh</numIndex>
-                                        <numIndex index="1">kk</numIndex>
-                                    </numIndex>
-                                    <numIndex index="39" type="array">
-                                        <numIndex index="0">Korean</numIndex>
-                                        <numIndex index="1">ko</numIndex>
-                                    </numIndex>
-                                    <numIndex index="40" type="array">
-                                        <numIndex index="0">lb</numIndex>
-                                        <numIndex index="1">lb</numIndex>
-                                    </numIndex>
-                                    <numIndex index="41" type="array">
-                                        <numIndex index="0">Lithuanian</numIndex>
-                                        <numIndex index="1">lt</numIndex>
-                                    </numIndex>
-                                    <numIndex index="42" type="array">
-                                        <numIndex index="0">Latvian</numIndex>
-                                        <numIndex index="1">lv</numIndex>
-                                    </numIndex>
-                                    <numIndex index="43" type="array">
-                                        <numIndex index="0">FYRO Macedonian</numIndex>
-                                        <numIndex index="1">mk</numIndex>
-                                    </numIndex>
-                                    <numIndex index="44" type="array">
-                                        <numIndex index="0">Malay</numIndex>
-                                        <numIndex index="1">ms</numIndex>
-                                    </numIndex>
-                                    <numIndex index="45" type="array">
-                                        <numIndex index="0">Norwegian (Bokmål)</numIndex>
-                                        <numIndex index="1">nb</numIndex>
-                                    </numIndex>
-                                    <numIndex index="46" type="array">
-                                        <numIndex index="0">Norwegian</numIndex>
-                                        <numIndex index="1">nn</numIndex>
-                                    </numIndex>
-                                    <numIndex index="47" type="array">
-                                        <numIndex index="0">Polish</numIndex>
-                                        <numIndex index="1">pl</numIndex>
-                                    </numIndex>
-                                    <numIndex index="48" type="array">
-                                        <numIndex index="0">Portuguese</numIndex>
-                                        <numIndex index="1">pt</numIndex>
-                                    </numIndex>
-                                    <numIndex index="49" type="array">
-                                        <numIndex index="0">Portuguese (Brazil)</numIndex>
-                                        <numIndex index="1">pt-br</numIndex>
-                                    </numIndex>
-                                    <numIndex index="50" type="array">
-                                        <numIndex index="0">Romanian</numIndex>
-                                        <numIndex index="1">ro</numIndex>
-                                    </numIndex>
-                                    <numIndex index="51" type="array">
-                                        <numIndex index="0">Russian</numIndex>
-                                        <numIndex index="1">ru</numIndex>
-                                    </numIndex>
-                                    <numIndex index="52" type="array">
-                                        <numIndex index="0">Slovak</numIndex>
-                                        <numIndex index="1">sk</numIndex>
-                                    </numIndex>
-                                    <numIndex index="53" type="array">
-                                        <numIndex index="0">Slovenian</numIndex>
-                                        <numIndex index="1">sl</numIndex>
-                                    </numIndex>
-                                    <numIndex index="54" type="array">
-                                        <numIndex index="0">Albanian</numIndex>
-                                        <numIndex index="1">sq</numIndex>
-                                    </numIndex>
-                                    <numIndex index="55" type="array">
-                                        <numIndex index="0">Serbian</numIndex>
-                                        <numIndex index="1">sr</numIndex>
-                                    </numIndex>
-                                    <numIndex index="56" type="array">
-                                        <numIndex index="0">Serbian (cyrl)</numIndex>
-                                        <numIndex index="1">sr-cyrl</numIndex>
-                                    </numIndex>
-                                    <numIndex index="57" type="array">
-                                        <numIndex index="0">Swedish</numIndex>
-                                        <numIndex index="1">sv</numIndex>
-                                    </numIndex>
-                                    <numIndex index="58" type="array">
-                                        <numIndex index="0">Thai</numIndex>
-                                        <numIndex index="1">th</numIndex>
-                                    </numIndex>
-                                    <numIndex index="59" type="array">
-                                        <numIndex index="0">Turkish</numIndex>
-                                        <numIndex index="1">tr</numIndex>
-                                    </numIndex>
-                                    <numIndex index="60" type="array">
-                                        <numIndex index="0">Ukrainian</numIndex>
-                                        <numIndex index="1">uk</numIndex>
-                                    </numIndex>
-                                    <numIndex index="61" type="array">
-                                        <numIndex index="0">Vietnamese</numIndex>
-                                        <numIndex index="1">vi</numIndex>
-                                    </numIndex>
-                                    <numIndex index="62" type="array">
-                                        <numIndex index="0">Chinese (S)</numIndex>
-                                        <numIndex index="1">zh-cn</numIndex>
-                                    </numIndex>
-                                    <numIndex index="63" type="array">
-                                        <numIndex index="0">Chinese (T)</numIndex>
-                                        <numIndex index="1">zh-tw</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <exclude>1</exclude>
+                        <label>LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.language</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default></default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">Afrikaans</numIndex>
+                                    <numIndex index="1">af</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">Arabic</numIndex>
+                                    <numIndex index="1">ar</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">Arabic (Algeria)</numIndex>
+                                    <numIndex index="1">ar-dz</numIndex>
+                                </numIndex>
+                                <numIndex index="3" type="array">
+                                    <numIndex index="0">Arabic (Kuwait)</numIndex>
+                                    <numIndex index="1">ar-kw</numIndex>
+                                </numIndex>
+                                <numIndex index="4" type="array">
+                                    <numIndex index="0">Arabic (Libya)</numIndex>
+                                    <numIndex index="1">ar-ly</numIndex>
+                                </numIndex>
+                                <numIndex index="5" type="array">
+                                    <numIndex index="0">Arabic (Morocco)</numIndex>
+                                    <numIndex index="1">ar-ma</numIndex>
+                                </numIndex>
+                                <numIndex index="6" type="array">
+                                    <numIndex index="0">Arabic (Saudi Arabia)</numIndex>
+                                    <numIndex index="1">ar-sa</numIndex>
+                                </numIndex>
+                                <numIndex index="7" type="array">
+                                    <numIndex index="0">Arabic (Tunisia)</numIndex>
+                                    <numIndex index="1">ar-tn</numIndex>
+                                </numIndex>
+                                <numIndex index="8" type="array">
+                                    <numIndex index="0">Bulgarian</numIndex>
+                                    <numIndex index="1">bg</numIndex>
+                                </numIndex>
+                                <numIndex index="9" type="array">
+                                    <numIndex index="0">Bosnian</numIndex>
+                                    <numIndex index="1">bs</numIndex>
+                                </numIndex>
+                                <numIndex index="10" type="array">
+                                    <numIndex index="0">Catalan</numIndex>
+                                    <numIndex index="1">ca</numIndex>
+                                </numIndex>
+                                <numIndex index="11" type="array">
+                                    <numIndex index="0">Czech</numIndex>
+                                    <numIndex index="1">cs</numIndex>
+                                </numIndex>
+                                <numIndex index="12" type="array">
+                                    <numIndex index="0">Danish</numIndex>
+                                    <numIndex index="1">da</numIndex>
+                                </numIndex>
+                                <numIndex index="13" type="array">
+                                    <numIndex index="0">German</numIndex>
+                                    <numIndex index="1">de</numIndex>
+                                </numIndex>
+                                <numIndex index="14" type="array">
+                                    <numIndex index="0">Greek</numIndex>
+                                    <numIndex index="1">el</numIndex>
+                                </numIndex>
+                                <numIndex index="15" type="array">
+                                    <numIndex index="0">English</numIndex>
+                                    <numIndex index="1"></numIndex>
+                                </numIndex>
+                                <numIndex index="16" type="array">
+                                    <numIndex index="0">English (Australia)</numIndex>
+                                    <numIndex index="1">en-au</numIndex>
+                                </numIndex>
+                                <numIndex index="17" type="array">
+                                    <numIndex index="0">English (United Kingdom)</numIndex>
+                                    <numIndex index="1">en-gb</numIndex>
+                                </numIndex>
+                                <numIndex index="18" type="array">
+                                    <numIndex index="0">English (New Zealand)</numIndex>
+                                    <numIndex index="1">en-nz</numIndex>
+                                </numIndex>
+                                <numIndex index="19" type="array">
+                                    <numIndex index="0">English (United States)</numIndex>
+                                    <numIndex index="1">en-us</numIndex>
+                                </numIndex>
+                                <numIndex index="20" type="array">
+                                    <numIndex index="0">Spanish</numIndex>
+                                    <numIndex index="1">es</numIndex>
+                                </numIndex>
+                                <numIndex index="21" type="array">
+                                    <numIndex index="0">Estonian</numIndex>
+                                    <numIndex index="1">et</numIndex>
+                                </numIndex>
+                                <numIndex index="22" type="array">
+                                    <numIndex index="0">Basque</numIndex>
+                                    <numIndex index="1">eu</numIndex>
+                                </numIndex>
+                                <numIndex index="23" type="array">
+                                    <numIndex index="0">Farsi</numIndex>
+                                    <numIndex index="1">fa</numIndex>
+                                </numIndex>
+                                <numIndex index="24" type="array">
+                                    <numIndex index="0">Finnish</numIndex>
+                                    <numIndex index="1">fi</numIndex>
+                                </numIndex>
+                                <numIndex index="25" type="array">
+                                    <numIndex index="0">French</numIndex>
+                                    <numIndex index="1">fr</numIndex>
+                                </numIndex>
+                                <numIndex index="26" type="array">
+                                    <numIndex index="0">French (Canada)</numIndex>
+                                    <numIndex index="1">fr-ca</numIndex>
+                                </numIndex>
+                                <numIndex index="27" type="array">
+                                    <numIndex index="0">French (Switzerland)</numIndex>
+                                    <numIndex index="1">fr-ca</numIndex>
+                                </numIndex>
+                                <numIndex index="28" type="array">
+                                    <numIndex index="0">Galician</numIndex>
+                                    <numIndex index="1">gl</numIndex>
+                                </numIndex>
+                                <numIndex index="29" type="array">
+                                    <numIndex index="0">Hebrew</numIndex>
+                                    <numIndex index="1">he</numIndex>
+                                </numIndex>
+                                <numIndex index="30" type="array">
+                                    <numIndex index="0">Hindi</numIndex>
+                                    <numIndex index="1">hi</numIndex>
+                                </numIndex>
+                                <numIndex index="31" type="array">
+                                    <numIndex index="0">Croatian</numIndex>
+                                    <numIndex index="1">hr</numIndex>
+                                </numIndex>
+                                <numIndex index="32" type="array">
+                                    <numIndex index="0">Hungarian</numIndex>
+                                    <numIndex index="1">hu</numIndex>
+                                </numIndex>
+                                <numIndex index="33" type="array">
+                                    <numIndex index="0">Indonesian</numIndex>
+                                    <numIndex index="1">id</numIndex>
+                                </numIndex>
+                                <numIndex index="34" type="array">
+                                    <numIndex index="0">Icelandic</numIndex>
+                                    <numIndex index="1">is</numIndex>
+                                </numIndex>
+                                <numIndex index="35" type="array">
+                                    <numIndex index="0">Italian</numIndex>
+                                    <numIndex index="1">it</numIndex>
+                                </numIndex>
+                                <numIndex index="36" type="array">
+                                    <numIndex index="0">Japanese</numIndex>
+                                    <numIndex index="1">ja</numIndex>
+                                </numIndex>
+                                <numIndex index="37" type="array">
+                                    <numIndex index="0">Georgian</numIndex>
+                                    <numIndex index="1">ka</numIndex>
+                                </numIndex>
+                                <numIndex index="38" type="array">
+                                    <numIndex index="0">Kazakh</numIndex>
+                                    <numIndex index="1">kk</numIndex>
+                                </numIndex>
+                                <numIndex index="39" type="array">
+                                    <numIndex index="0">Korean</numIndex>
+                                    <numIndex index="1">ko</numIndex>
+                                </numIndex>
+                                <numIndex index="40" type="array">
+                                    <numIndex index="0">lb</numIndex>
+                                    <numIndex index="1">lb</numIndex>
+                                </numIndex>
+                                <numIndex index="41" type="array">
+                                    <numIndex index="0">Lithuanian</numIndex>
+                                    <numIndex index="1">lt</numIndex>
+                                </numIndex>
+                                <numIndex index="42" type="array">
+                                    <numIndex index="0">Latvian</numIndex>
+                                    <numIndex index="1">lv</numIndex>
+                                </numIndex>
+                                <numIndex index="43" type="array">
+                                    <numIndex index="0">FYRO Macedonian</numIndex>
+                                    <numIndex index="1">mk</numIndex>
+                                </numIndex>
+                                <numIndex index="44" type="array">
+                                    <numIndex index="0">Malay</numIndex>
+                                    <numIndex index="1">ms</numIndex>
+                                </numIndex>
+                                <numIndex index="45" type="array">
+                                    <numIndex index="0">Norwegian (Bokmål)</numIndex>
+                                    <numIndex index="1">nb</numIndex>
+                                </numIndex>
+                                <numIndex index="46" type="array">
+                                    <numIndex index="0">Norwegian</numIndex>
+                                    <numIndex index="1">nn</numIndex>
+                                </numIndex>
+                                <numIndex index="47" type="array">
+                                    <numIndex index="0">Polish</numIndex>
+                                    <numIndex index="1">pl</numIndex>
+                                </numIndex>
+                                <numIndex index="48" type="array">
+                                    <numIndex index="0">Portuguese</numIndex>
+                                    <numIndex index="1">pt</numIndex>
+                                </numIndex>
+                                <numIndex index="49" type="array">
+                                    <numIndex index="0">Portuguese (Brazil)</numIndex>
+                                    <numIndex index="1">pt-br</numIndex>
+                                </numIndex>
+                                <numIndex index="50" type="array">
+                                    <numIndex index="0">Romanian</numIndex>
+                                    <numIndex index="1">ro</numIndex>
+                                </numIndex>
+                                <numIndex index="51" type="array">
+                                    <numIndex index="0">Russian</numIndex>
+                                    <numIndex index="1">ru</numIndex>
+                                </numIndex>
+                                <numIndex index="52" type="array">
+                                    <numIndex index="0">Slovak</numIndex>
+                                    <numIndex index="1">sk</numIndex>
+                                </numIndex>
+                                <numIndex index="53" type="array">
+                                    <numIndex index="0">Slovenian</numIndex>
+                                    <numIndex index="1">sl</numIndex>
+                                </numIndex>
+                                <numIndex index="54" type="array">
+                                    <numIndex index="0">Albanian</numIndex>
+                                    <numIndex index="1">sq</numIndex>
+                                </numIndex>
+                                <numIndex index="55" type="array">
+                                    <numIndex index="0">Serbian</numIndex>
+                                    <numIndex index="1">sr</numIndex>
+                                </numIndex>
+                                <numIndex index="56" type="array">
+                                    <numIndex index="0">Serbian (cyrl)</numIndex>
+                                    <numIndex index="1">sr-cyrl</numIndex>
+                                </numIndex>
+                                <numIndex index="57" type="array">
+                                    <numIndex index="0">Swedish</numIndex>
+                                    <numIndex index="1">sv</numIndex>
+                                </numIndex>
+                                <numIndex index="58" type="array">
+                                    <numIndex index="0">Thai</numIndex>
+                                    <numIndex index="1">th</numIndex>
+                                </numIndex>
+                                <numIndex index="59" type="array">
+                                    <numIndex index="0">Turkish</numIndex>
+                                    <numIndex index="1">tr</numIndex>
+                                </numIndex>
+                                <numIndex index="60" type="array">
+                                    <numIndex index="0">Ukrainian</numIndex>
+                                    <numIndex index="1">uk</numIndex>
+                                </numIndex>
+                                <numIndex index="61" type="array">
+                                    <numIndex index="0">Vietnamese</numIndex>
+                                    <numIndex index="1">vi</numIndex>
+                                </numIndex>
+                                <numIndex index="62" type="array">
+                                    <numIndex index="0">Chinese (S)</numIndex>
+                                    <numIndex index="1">zh-cn</numIndex>
+                                </numIndex>
+                                <numIndex index="63" type="array">
+                                    <numIndex index="0">Chinese (T)</numIndex>
+                                    <numIndex index="1">zh-tw</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </settings.language>
 
                     <settings.view>
-                        <TCEforms>
-                            <exclude>1</exclude>
-                            <label>LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.view</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.view.dayGridMonth</numIndex>
-                                        <numIndex index="1">dayGridMonth</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.view.timeGridWeek</numIndex>
-                                        <numIndex index="1">timeGridWeek</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.view.timeGridDay</numIndex>
-                                        <numIndex index="1">timeGridDay</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <exclude>1</exclude>
+                        <label>LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.view</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.view.dayGridMonth</numIndex>
+                                    <numIndex index="1">dayGridMonth</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.view.timeGridWeek</numIndex>
+                                    <numIndex index="1">timeGridWeek</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.view.timeGridDay</numIndex>
+                                    <numIndex index="1">timeGridDay</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </settings.view>
 
                     <settings.category>
-                        <TCEforms>
-                            <exclude>1</exclude>
-                            <label>LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.parent_category</label>
-                            <config>
-                                <type>group</type>
-                                <internal_type>db</internal_type>
-                                <allowed>sys_category</allowed>
-                                <size>1</size>
-                            </config>
-                        </TCEforms>
+                        <exclude>1</exclude>
+                        <label>LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.parent_category</label>
+                        <config>
+                            <type>group</type>
+                            <internal_type>db</internal_type>
+                            <allowed>sys_category</allowed>
+                            <size>1</size>
+                        </config>
                     </settings.category>
 
                     <settings.templateLayout>
-                        <TCEforms>
-                            <label>LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.templateLayout</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <itemsProcFunc>Mediadreams\MdFullcalendar\Hooks\TemplateLayouts->getTemplateLayouts</itemsProcFunc>
-                                <items>
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0"></numIndex>
-                                        <numIndex index="1"></numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:md_fullcalendar/Resources/Private/Language/locallang_db.xlf:flexform.templateLayout</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <itemsProcFunc>Mediadreams\MdFullcalendar\Hooks\TemplateLayouts->getTemplateLayouts</itemsProcFunc>
+                            <items>
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0"></numIndex>
+                                    <numIndex index="1"></numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </settings.templateLayout>
                 </el>
             </ROOT>
-        </ewsfeusers_users>
+        </sDEF>
     </sheets>
 </T3DataStructure>

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "source": "https://github.com/cdaecke/md_fullcalendar"
     },
     "require": {
-        "typo3/cms-core": "^11.5 || ^12.4",
-        "lochmueller/calendarize": "^12.0 || ^13.0"
+        "typo3/cms-core": "^13.4",
+        "lochmueller/calendarize": "^12.0 || ^13.0 || ^14.0"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -23,8 +23,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '4.0.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-12.4.99',
-            'calendarize' => '12.0.0-13.99.99',
+            'typo3' => '13.4.99',
+            'calendarize' => '12.0.0-14.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Doesn't actually need that much work for the extension to run on TYPO3 v13 so here's my take.

*I did set the TYPO3 version constraint to `TYPO3 13` only because I couldn't check if the FlexForms changes would be working in TYPO3 12 and 11 too. If they do feel free to change it back to supporting TYPO3 11 through 13.*

#27 